### PR TITLE
hotfix for the login validator.

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -25,9 +25,9 @@ class SignUpForm(FlaskForm):
 	])
 	password = StringField('Password', validators=[
 		DataRequired(),
-		Regexp( ##regex rule for passwords
-			r'^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$',
-			message="Password must be at least 8 characters long and include a letter, a number, and a special character."
+		Regexp( ##regex rule for passwords, the special character set is !@#$%^&*()_+-=[]{};:'",.<>/?\|`~
+			r'^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};:\'",.<>/?\\|`~])[A-Za-z\d!@#$%^&*()_+\-=\[\]{};:\'",.<>/?\\|`~]{8,}$',
+		message="Password must be at least 8 characters long and include a letter, a number, and a special character."
 		)
 	])
 	height = IntegerField('Height (in cm)', validators=[


### PR DESCRIPTION
Closes: #34 

Expanded the login validator to allow a greater set of special characters. 

For reference, the special character set allowed now is !@#$%^&*()_+-=[]{};:'",.<>/?\|`~ (on top of letters and numbers).